### PR TITLE
Replace deprecated CliBuilder with the one from cli common

### DIFF
--- a/GithubTopRankCrawler.groovy
+++ b/GithubTopRankCrawler.groovy
@@ -1,3 +1,4 @@
+import groovy.cli.commons.CliBuilder
 import groovy.json.JsonOutput
 import groovy.json.JsonSlurper
 
@@ -8,11 +9,14 @@ class GithubTopRankCrawler {
     static String TOP_JSON = 'top.json'
 
     static void main(String[] args) {
-
-        def cli = new CliBuilder(usage: 'groovy GithubTopRankCrawler <options>')
-        cli.l(longOpt: 'language', args: 1, 'specify a language, e.g. go/java')
-        cli.s(longOpt: 'shallow', 'use shallow clone')
-        cli.d(longOpt: 'dir', args: 1, 'specify the target directory')
+        def cli = new CliBuilder(
+                usage: 'groovy GithubTopRankCrawler <options>'
+        )
+        cli.with {
+            l(longOpt: 'language', 'Programming language', args: 1, required: true)
+            s(longOpt: 'shallow', 'Shallow', args: 1, required: true)
+            d(longOpt: 'dir', 'Target directory', args: 1, required: true)
+        }
 
         def options = cli.parse(args)
 
@@ -37,7 +41,7 @@ class GithubTopRankCrawler {
             baseDir.mkdir()
         }
         getTop1000(options.l, baseDir).each {
-            cloneOne(baseDir, it.full_name, it.clone_url, options.s)
+            cloneOne(baseDir, it.full_name, it.clone_url, options.s.toBoolean())
         }
     }
 

--- a/JavaBuildToolScanner.groovy
+++ b/JavaBuildToolScanner.groovy
@@ -1,3 +1,5 @@
+import groovy.cli.commons.CliBuilder
+
 class JavaBuildToolScanner {
     static List<Tool> JAVA_TOOLS = [new Tool(name: 'Maven', identityFiles: ['pom.xml']),
                                     new Tool(name: 'Ant', identityFiles: ['build.xml']),
@@ -7,14 +9,19 @@ class JavaBuildToolScanner {
                                     new Tool(name: 'Make', identityFiles: ['Makefile', 'makefile'])]
 
     static main(String[] args) {
-        def cli = new CliBuilder(usage: 'groovy GithubTopRankCrawler <options>')
-        cli.s(longOpt: 'start', args: 1, 'start date, yyyy-MM-dd')
-        cli.e(longOpt: 'end', 'end date, yyyy-MM-dd')
-        cli.d(longOpt: 'dir', args: 1, 'specify the target directory')
-        cli.i(longOpt: 'interval-days', args: 1, 'the interval in days')
+        def cli = new CliBuilder(
+                usage: 'groovy JavaBuildToolScanner.groovy -s startDate(yyyy-MM-dd) -e endDate(yyyy-MM-dd) -d directory -i intervalDays',
+        )
+        cli.with {
+            s(longOpt: 'start', 'Start date', args: 1, required: true)
+            e(longOpt: 'end', 'End date', args: 1, required: true)
+            d(longOpt: 'dir', 'Target output directory', args: 1, required: true)
+            i(longOpt: 'interval-days', 'Interval in days', args: 1, required: true)
+        }
 
         def options = cli.parse(args)
         if (!options) {
+            println('you must pass a bunch of arguments')
             return
         }
 


### PR DESCRIPTION
I was trying to run it and update it, but I can't seem to get the old `CliBuilder` to pick up the arguments. And once I switch to the one in `groovy.cli.common.CliBuilder` it seems to work fine.